### PR TITLE
C — RoleTabsShell: drop invalid BottomTabs options, dedup 768 breakpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ When adding a feature that exists for multiple roles, the same screen name (e.g.
 
 ### RoleTabsShell — one shell, three layouts
 
-`components/layout/RoleTabsShell.tsx` is the chrome rendered by each role's `_layout.tsx`. Each role layout passes a `navItems: RoleNavItem[]` array declaring its tabs. The shell branches on screen width (`< 768px` = mobile):
+`components/layout/RoleTabsShell.tsx` is the chrome rendered by each role's `_layout.tsx`. Each role layout passes a `navItems: RoleNavItem[]` array declaring its tabs. The shell branches on `MOBILE_BREAKPOINT` from `lib/breakpoints.ts` (currently 768px):
 
 - **Mobile**: bottom `Tabs` bar + frosted glass top bar. Items with `segment === 'notification'` or `'settings'` are hidden from the tab bar (`href: null`) and surfaced as top-right icons instead.
 - **Desktop/web**: collapsible left sidebar; the `Tabs` bar is rendered with `height: 0` (hidden) so expo-router still mounts the tab screens as routes.

--- a/components/layout/RoleTabsShell.test.tsx
+++ b/components/layout/RoleTabsShell.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react-native';
 import { useWindowDimensions } from 'react-native';
 import { RoleTabsShell, RoleNavItem } from './RoleTabsShell';
 import { useAuthStore, UserRole } from '@/store/authStore';
+import { MOBILE_BREAKPOINT } from '@/lib/breakpoints';
 
 jest.mock('react-native/Libraries/Utilities/useWindowDimensions');
 
@@ -38,5 +39,16 @@ describe('RoleTabsShell', () => {
       <RoleTabsShell navItems={navItems} roleName="Admin" avatarFallback="A" />,
     );
     expect(getByTestId('tabs')).toBeTruthy();
+  });
+
+  it('renders desktop sidebar at exactly MOBILE_BREAKPOINT (768)', () => {
+    // Branching is width < MOBILE_BREAKPOINT, so width === 768 is desktop.
+    setDimensions(MOBILE_BREAKPOINT);
+    const { getByTestId } = render(
+      <RoleTabsShell navItems={navItems} roleName="Admin" avatarFallback="A" />,
+    );
+    expect(getByTestId('tabs')).toBeTruthy();
+    // Sidebar collapse chevron only renders in desktop mode.
+    expect(getByTestId('icon-chevron-back')).toBeTruthy();
   });
 });

--- a/components/layout/RoleTabsShell.tsx
+++ b/components/layout/RoleTabsShell.tsx
@@ -13,6 +13,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuthStore } from '@/store/authStore';
 import { isSidebarRouteActive } from '@/lib/sidebarNav';
+import { MOBILE_BREAKPOINT } from '@/lib/breakpoints';
 
 export interface RoleNavItem {
   /** Must match the route file name (e.g. dashboard.tsx → "dashboard") */
@@ -24,7 +25,6 @@ export interface RoleNavItem {
   route: string;
 }
 
-const MOBILE_BREAKPOINT = 768;
 const SIDEBAR_WIDTH = 240;
 const SIDEBAR_COLLAPSED = 68;
 
@@ -173,9 +173,6 @@ export function RoleTabsShell({ navItems, roleName, avatarFallback }: RoleTabsSh
   const notificationItem = navItems.find(i => i.segment === 'notification');
   const settingsItem = navItems.find(i => i.segment === 'settings');
   const dashboardItem = navItems.find(i => i.segment === 'dashboard');
-  const visibleTabCount = navItems.filter(
-    i => i.segment !== 'notification' && i.segment !== 'settings',
-  ).length;
 
   const notifActive = notificationItem ? isActive(notificationItem.route) : false;
   const settingsActive = settingsItem ? isActive(settingsItem.route) : false;
@@ -248,7 +245,6 @@ export function RoleTabsShell({ navItems, roleName, avatarFallback }: RoleTabsSh
                 marginBottom: 2,
               },
               tabBarIconStyle: { marginTop: 4 },
-              tabBarScrollEnabled: isMobile && visibleTabCount > 4,
               tabBarStyle: isMobile
                 ? {
                     paddingTop: 6,
@@ -292,9 +288,6 @@ export function RoleTabsShell({ navItems, roleName, avatarFallback }: RoleTabsSh
                 minHeight: 48,
               },
               tabBarHideOnKeyboard: true,
-              sceneContainerStyle: {
-                backgroundColor: '#F9FAFB',
-              },
             }}
           >
             {navItems.map(item => {

--- a/lib/breakpoints.ts
+++ b/lib/breakpoints.ts
@@ -1,0 +1,1 @@
+export const MOBILE_BREAKPOINT = 768;

--- a/lib/dashboardResponsive.ts
+++ b/lib/dashboardResponsive.ts
@@ -1,11 +1,9 @@
 import { useWindowDimensions } from 'react-native';
-
-/** Matches app shell `(admin|staff|student)/_layout` mobile breakpoint */
-export const DASHBOARD_COMPACT_BREAKPOINT = 768;
+import { MOBILE_BREAKPOINT } from './breakpoints';
 
 export function useDashboardCompact() {
   const { width } = useWindowDimensions();
-  const isCompact = width < DASHBOARD_COMPACT_BREAKPOINT;
+  const isCompact = width < MOBILE_BREAKPOINT;
   return {
     isCompact,
     /** Scroll content horizontal padding */


### PR DESCRIPTION
Closes #20. **Stacked on #23** (base is `issue/a-test-scaffolding`, not `master`).

## Summary

- Remove `tabBarScrollEnabled` from `<Tabs>` `screenOptions` — it's a Material Top Tabs option and a runtime no-op on Bottom Tabs. Also drop the now-unused `visibleTabCount` local.
- Remove `sceneContainerStyle` from the same `screenOptions` object. Same class of bug (not a valid `BottomTabNavigationOptions` key), masked under `tsc` until `tabBarScrollEnabled` was gone. Scope note below.
- Introduce `lib/breakpoints.ts` as the single source of `MOBILE_BREAKPOINT`. `components/layout/RoleTabsShell.tsx` and `lib/dashboardResponsive.ts` both import from it. `DASHBOARD_COMPACT_BREAKPOINT` is removed (grep confirmed no external importers).
- Extend `components/layout/RoleTabsShell.test.tsx` with an edge case at `width === MOBILE_BREAKPOINT` (exactly 768 → desktop mode, since the branch is strict `<`).
- Update `CLAUDE.md` to reference the constant by name.

## Test plan

- [x] `npm test` — 27/27 pass locally (~50s in this run, mostly jest startup)
- [x] `npx tsc --noEmit` — **only** the pre-existing `services/googleDriveService.ts(18,26): Cannot find module 'expo-sharing'` remains; `tabBarScrollEnabled` and `sceneContainerStyle` errors both gone
- [ ] CI workflow runs green on this PR

## Notes for reviewers

- **Scope expansion, heads-up:** The issue only called out `tabBarScrollEnabled`. Removing it unmasked `sceneContainerStyle` on the *same* `screenOptions` object (tsc reports one bad key per object literal at a time). Same class of bug; leaving it would have violated this issue's own acceptance criterion ("tsc produces no errors related to this file"). Deleted it too. Visual behavior is preserved — the parent `<View style={styles.root}>` already has `backgroundColor: '#F9FAFB'`, which is what `sceneContainerStyle` was setting.
- `lib/breakpoints.ts` exports only the one constant. If a separate "dashboard-compact" threshold ever diverges from mobile, add it in that same file.
- The `expo-sharing` tsc error lives in dead code (`services/googleDriveService.ts`) which is slated for deletion in Issue D (#21). Not touched here.
- Verified via grep: zero literal `768` remain in `.ts`/`.tsx` outside `lib/breakpoints.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)