### PR TITLE
fix: wire dashboard dismiss/clear to backend and drop setTimeout logout (#22)

### DIFF
--- a/app/(shared)/settings.tsx
+++ b/app/(shared)/settings.tsx
@@ -173,19 +173,9 @@ export default function SettingsScreen() {
     });
   };
 
-  //  UPDATED: Logout with toast
-  const handleLogout = () => {
-    Toast.show({
-      type: 'info',
-      text1: 'Logging Out',
-      text2: 'See you soon!',
-      position: 'top',
-      visibilityTime: 2000,
-    });
-    
-    setTimeout(() => {
-      logout();
-    }, 500);
+  //  UPDATED: Logout (auth guard redirects to (auth)/login once user is null)
+  const handleLogout = async () => {
+    await logout();
   };
 
   const getInitials = () => {

--- a/app/(staff)/dashboard.test.tsx
+++ b/app/(staff)/dashboard.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for Issue #22 — staff dashboard UX bug fixes.
+ *
+ * Bug 1: handleDismissActivity / handleClearAll were client-only.
+ *        They must now hit DataService.deleteActivity / deleteAllActivity
+ *        and roll back the optimistic update on error.
+ *
+ * Bug 2: handleLogout used setTimeout(logout, 500). It must now just
+ *        await logout() — no dangling timers.
+ */
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import MockAdapter from 'axios-mock-adapter';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import api from '@/services/api';
+import { useAuthStore, UserRole } from '@/store/authStore';
+
+// Mock the toast module at the top level so we can spy on Toast.show calls.
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+// Mock the responsive hook so the screen renders without layout plumbing.
+jest.mock('@/lib/dashboardResponsive', () => ({
+  useDashboardCompact: () => ({
+    isCompact: false,
+    contentPaddingX: 16,
+    contentPaddingY: 16,
+    greetingFontSize: 24,
+    secondaryFontSize: 14,
+    cardPadding: 16,
+    sectionGap: 16,
+  }),
+}));
+
+// Require AFTER the mocks above so the screen picks up the mocked modules.
+const Toast = require('react-native-toast-message').default;
+const StaffDashboard = require('./dashboard').default;
+
+const mock = new MockAdapter(api);
+
+const fakeUser = {
+  id: 'u1',
+  email: 'staff@example.com',
+  name: 'Staff Member',
+  role: UserRole.TEACHER,
+};
+
+const statsPayload = {
+  totalStaff: 1,
+  staffTrend: '+0',
+  activeSchedules: 0,
+  schedulesTrend: '',
+  notificationsSent: 0,
+  notificationsTrend: '',
+  totalDocuments: 0,
+  documentsTrend: '',
+  chartData: [],
+};
+
+const activityPayload = [
+  { id: '1', title: 'First activity', author: 'Alice', timestamp: new Date().toISOString() },
+  { id: '2', title: 'Second activity', author: 'Bob', timestamp: new Date().toISOString() },
+];
+
+async function seedAuth() {
+  await AsyncStorage.clear();
+  useAuthStore.setState({ user: fakeUser, isLoading: false, error: null });
+}
+
+beforeEach(async () => {
+  mock.reset();
+  (Toast.show as jest.Mock).mockClear();
+  await seedAuth();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+async function renderDashboard() {
+  mock.onGet('/api/v1/dashboard/stats').reply(200, statsPayload);
+  mock.onGet('/api/v1/dashboard/activity').reply(200, activityPayload);
+  const utils = render(<StaffDashboard />);
+  // Wait for initial data load to finish (activity items appear).
+  await waitFor(() => {
+    expect(utils.getByText('First activity')).toBeTruthy();
+  });
+  return utils;
+}
+
+describe('StaffDashboard — handleDismissActivity', () => {
+  it('removes the item and calls DataService.deleteActivity on success', async () => {
+    let capturedUrl: string | undefined;
+    mock.onDelete(/\/api\/v1\/dashboard\/activity\/.+/).reply((config) => {
+      capturedUrl = config.url;
+      return [204];
+    });
+
+    const { getByText, queryByText, getAllByTestId } = await renderDashboard();
+
+    // There are two dismiss buttons (one per activity). The first is for id '1'.
+    const dismissButtons = getAllByTestId('icon-close');
+    fireEvent.press(dismissButtons[0].parent ?? dismissButtons[0]);
+
+    await waitFor(() => {
+      expect(queryByText('First activity')).toBeNull();
+    });
+    expect(getByText('Second activity')).toBeTruthy();
+    expect(capturedUrl).toBe('/api/v1/dashboard/activity/1');
+  });
+
+  it('rolls back and shows an error toast when the delete fails', async () => {
+    mock.onDelete(/\/api\/v1\/dashboard\/activity\/.+/).reply(500, { detail: 'boom' });
+
+    const { getByText, getAllByTestId } = await renderDashboard();
+
+    const dismissButtons = getAllByTestId('icon-close');
+    fireEvent.press(dismissButtons[0].parent ?? dismissButtons[0]);
+
+    // After the failed request, the item should reappear in the list.
+    await waitFor(() => {
+      expect(getByText('First activity')).toBeTruthy();
+    });
+
+    const errorCall = (Toast.show as jest.Mock).mock.calls.find(
+      ([arg]) => arg && arg.type === 'error',
+    );
+    expect(errorCall).toBeDefined();
+    expect(errorCall[0].text1).toBe('Could not dismiss');
+  });
+});
+
+describe('StaffDashboard — handleLogout (Bug #2)', () => {
+  it('calls logout() and schedules no timers', async () => {
+    // Make logout a jest mock we can assert on.
+    const logoutSpy = jest.fn(async () => {
+      // Simulate the real store clearing the user.
+      useAuthStore.setState({ user: null });
+    });
+    useAuthStore.setState({ logout: logoutSpy });
+
+    const { getAllByTestId } = await renderDashboard();
+
+    // The header logout button renders an Ionicon with name="log-out-outline".
+    const logoutIcons = getAllByTestId('icon-log-out-outline');
+    expect(logoutIcons.length).toBeGreaterThan(0);
+
+    // Bug 2 was `setTimeout(logout, 500)`. Spy on setTimeout and confirm the
+    // press handler does NOT schedule a long-running timer (anything >= 100ms
+    // would be the 500ms logout delay; React/axios internals schedule 0–few ms
+    // microtask-ish timers that we tolerate).
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    setTimeoutSpy.mockClear();
+
+    await act(async () => {
+      fireEvent.press(logoutIcons[0].parent ?? logoutIcons[0]);
+    });
+
+    expect(logoutSpy).toHaveBeenCalledTimes(1);
+
+    const suspiciousTimers = setTimeoutSpy.mock.calls.filter(
+      ([, delay]) => typeof delay === 'number' && delay >= 100,
+    );
+    expect(suspiciousTimers).toEqual([]);
+
+    setTimeoutSpy.mockRestore();
+  });
+});

--- a/app/(staff)/dashboard.tsx
+++ b/app/(staff)/dashboard.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -59,18 +60,59 @@ export default function StaffDashboard() {
     }
   };
 
-  const handleDismissActivity = (id: string) => {
+  const handleDismissActivity = async (id: string) => {
+    const previous = activities;
     setActivities(prev => prev.filter(a => a.id !== id));
+    try {
+      await DataService.deleteActivity(id);
+    } catch (err) {
+      setActivities(previous);
+      Toast.show({
+        type: 'error',
+        text1: 'Could not dismiss',
+        position: 'top',
+        visibilityTime: 2000,
+      });
+    }
   };
 
   const handleClearAll = () => {
-    setActivities([]);
-    Toast.show({ type: 'success', text1: 'Activity cleared', position: 'top', visibilityTime: 1500 });
+    Alert.alert(
+      'Clear all activity?',
+      "This will remove all activity items. This can't be undone.",
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear all',
+          style: 'destructive',
+          onPress: async () => {
+            const previous = activities;
+            setActivities([]);
+            try {
+              await DataService.deleteAllActivity();
+              Toast.show({
+                type: 'success',
+                text1: 'Activity cleared',
+                position: 'top',
+                visibilityTime: 1500,
+              });
+            } catch (err) {
+              setActivities(previous);
+              Toast.show({
+                type: 'error',
+                text1: 'Could not clear activity',
+                position: 'top',
+                visibilityTime: 2000,
+              });
+            }
+          },
+        },
+      ],
+    );
   };
 
-  const handleLogout = () => {
-    Toast.show({ type: 'info', text1: 'Logging out', text2: 'See you soon!', position: 'top', visibilityTime: 1500 });
-    setTimeout(() => logout(), 500);
+  const handleLogout = async () => {
+    await logout();
   };
 
   const handleRefresh = () => {


### PR DESCRIPTION
## Summary

Closes #22.

- **Bug 1 — dismiss / clear-all were client-only.** `handleDismissActivity` and `handleClearAll` on the staff dashboard only mutated local state, so dismissed items reappeared on the next refresh. Both now call `DataService.deleteActivity` / `DataService.deleteAllActivity` (endpoints already existed in `services/dataService.ts`) with optimistic UI + rollback-on-error and an error toast. `handleClearAll` also now confirms via `Alert.alert` before clearing.
- **Bug 2 — `setTimeout(logout, 500)` anti-pattern.** The prior pattern left a dangling timer on unmount and races the auth redirect. Replaced with a straight `async` that awaits `logout()` — the auth guard in `app/_layout.tsx` redirects to `(auth)/login` once `user === null`, so no manual navigation is needed. Applied in `app/(staff)/dashboard.tsx` and `app/(shared)/settings.tsx`.

## Test plan

- [x] `npx tsc --noEmit` — only the pre-existing `tabBarScrollEnabled` error on `components/layout/RoleTabsShell.tsx:251` (owned by Issue C / #25); nothing new.
- [x] `npm test` — 30 tests across 6 suites, all passing, including the 3 new cases.
- [x] `grep -rn 'setTimeout.*logout\|logout.*setTimeout' app components` — zero matches in source (only descriptive comments in the new test file).
- [x] New tests in `app/(staff)/dashboard.test.tsx`:
  - dismiss happy path — confirms `DELETE /api/v1/dashboard/activity/:id` is hit and item disappears.
  - dismiss error rollback — 500 response restores item and fires an error toast.
  - logout no-setTimeout — spies on `global.setTimeout`, asserts no timer >=100ms is scheduled by the press (tolerates low-ms React/axios internals).
- [ ] Manual smoke on a running backend — dismiss an activity, refresh, confirm it stays gone; clear all, confirm Alert prompt + persistence.

## Notes for reviewers

- **Stacked on #26 (Issue D).** Base is `issue/d-selectors-dead-code`, not `master`. The dashboard already uses the new `useUser()` / `useLogout()` selectors from D; I did not revert them.
- **setTimeout sweep:** the grep hit 5 `setTimeout` call sites. Only 2 were logout-related (`app/(staff)/dashboard.tsx`, `app/(shared)/settings.tsx`) — both fixed. The other 3 (`app/(admin)/schedules.tsx`, `app/(shared)/schedules.tsx`, `app/(student)/schedules.tsx`) are scroll-to-position deferrals unrelated to auth — left untouched per scope.
- **Test mocking strategy:** went with `axios-mock-adapter` on the shared `api` instance (matches `services/dataService.test.ts`) rather than module-level mocks on `@/services/dataService`. `react-native-toast-message` and `@/lib/dashboardResponsive` are module-level `jest.mock`s; auth is set via `useAuthStore.setState(...)` the same way `store/authStore.selectors.test.tsx` does it.
- **Gotcha:** originally tried `jest.useFakeTimers()` + `jest.getTimerCount()` for the logout test, but React/axios internals schedule 1–2 short timers during press, which made the strict-count assertion flaky. The final test spies on `global.setTimeout` and only fails on timers `>= 100ms` (the 500ms logout delay would have hit). The assertion still catches the original bug.
- Did NOT touch: `services/dataService.ts`, `services/api.ts`, `lib/authLogout.ts`, `store/authStore.ts`, or `components/layout/RoleTabsShell.tsx:251` — per hard constraints.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>